### PR TITLE
refactored _requestNewScan function, it is more readable now

### DIFF
--- a/charts/polkadot-watcher-transaction/Chart.yaml
+++ b/charts/polkadot-watcher-transaction/Chart.yaml
@@ -1,4 +1,4 @@
 description: Polkadot Watcher
 name: polkadot-watcher-transaction
-version: v0.5.0
+version: v0.5.1
 apiVersion: v2

--- a/charts/polkadot-watcher-transaction/values.yaml
+++ b/charts/polkadot-watcher-transaction/values.yaml
@@ -2,7 +2,7 @@ environment: production
 
 image:
   repo: web3f/polkadot-watcher-transaction
-  tag: v0.5.0
+  tag: v0.5.1
 
 config:
   endpoint: "wss://kusama-rpc.polkadot.io/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polkadot-watcher-transaction",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Monitor events on Polkadot networks, specifically transactions",
   "repository": "git@github.com:w3f/polkadot-watcher-csv-exporter.git",
   "author": "W3F Infrastructure Team <devops@web3.foundation>",

--- a/src/subscriptionModules/eventScannerBased.ts
+++ b/src/subscriptionModules/eventScannerBased.ts
@@ -88,6 +88,10 @@ export class EventScannerBased implements ISubscriptionModule{
 
     private _requestNewScan = async (): Promise<void> => {
       if(this.isScanOngoing){
+        /*
+        A new scan can be trigger asynchronously for various reasons (see the subscribe function above). 
+        To ensure an exactly once detection and delivery, only one scan is allowed at time.  
+        */
         this.isNewScanRequired = true
         this.logger.info(`new scan queued...`)
       }
@@ -97,6 +101,9 @@ export class EventScannerBased implements ISubscriptionModule{
             this.isScanOngoing = true
             this.isNewScanRequired = false
             await this._scanForTransferEvents()
+            /*
+            An additional scan will be processed immediately if queued by any of the triggers.
+            */
           } while (this.isNewScanRequired);
         } catch (error) {
           this.logger.error(`last SCAN had an issue !: ${JSON.stringify(error)}`)

--- a/src/subscriptionModules/eventScannerBased.ts
+++ b/src/subscriptionModules/eventScannerBased.ts
@@ -90,24 +90,25 @@ export class EventScannerBased implements ISubscriptionModule{
       if(this.isScanOngoing){
         this.isNewScanRequired = true
         this.logger.info(`new scan queued...`)
-      }else{
+      }
+      else{
         try {
-          await this._scanForTransferEvents()
+          do {
+            this.isScanOngoing = true
+            this.isNewScanRequired = false
+            await this._scanForTransferEvents()
+          } while (this.isNewScanRequired);
         } catch (error) {
           this.logger.error(`last SCAN had an issue !: ${JSON.stringify(error)}`)
         } finally {
           this.isScanOngoing = false
         }
-
-        if(this.isNewScanRequired){
-          this._requestNewScan()
-        }
       } 
     }
 
+    // this function shouldn't be called directly, use _requestNewScan instead
+    // in this way, simultaneous executions are prevented
     private _scanForTransferEvents = async (): Promise<void> => {
-      this.isScanOngoing = true
-      this.isNewScanRequired = false
 
       const currentBlockNumber = (await this.api.rpc.chain.getHeader()).number.unwrap().toNumber()
       const lastCheckedBlock = await this._getLastCheckedBlock()
@@ -217,10 +218,6 @@ export class EventScannerBased implements ISubscriptionModule{
       this.logger.debug(`Delegating to the Notifier the New Transfer Event notification...`)
       this.logger.debug(JSON.stringify(data))
       return await this.notifier.newTransfer(data)
-
-      //TODO now it is just a mock
-      // await this.notifier.newTransfer(data)
-      // return true
     }
 
     private _getLastCheckedBlock = async (): Promise<number> => {


### PR DESCRIPTION
FYI: JavaScript doesn’t have any real concurrency, adding simple checks and mutating the variables involved is sufficient to safely control the concurrency

all the concurrency variables are now referred just inside the _requestNewScan function

https://github.com/w3f/SecOps/issues/102